### PR TITLE
Update Lock.sol

### DIFF
--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.9;
 contract Lock {
     uint public unlockTime;
     address payable public owner;
+    bool private isWithdrawing;
 
     event Withdrawal(uint amount, uint when);
 
@@ -15,14 +16,24 @@ contract Lock {
 
         unlockTime = _unlockTime;
         owner = payable(msg.sender);
+        isWithdrawing = false;
     }
 
-    function withdraw() public {
+    modifier preventReentrancy() {
+        require(!isWithdrawing, "Reentrancy attempt detected!");
+        isWithdrawing = true;
+        _;
+        isWithdrawing = false;
+    }
+
+    function withdraw() public preventReentrancy {
         require(block.timestamp >= unlockTime, "You can't withdraw yet");
         require(msg.sender == owner, "You aren't the owner");
 
-        emit Withdrawal(address(this).balance, block.timestamp);
+        uint balance = address(this).balance;
+        emit Withdrawal(balance, block.timestamp);
 
-        owner.transfer(address(this).balance);
+        (bool sent, ) = owner.call{value: balance}("");
+        require(sent, "Failed to send Ether");
     }
 }


### PR DESCRIPTION
The contract uses transfer for sending Ether, which is safe but can potentially be a bit more expensive in terms of gas than send or call. Since Solidity 0.6.x, it's recommended to use call for Ether transfers: 

(bool sent, ) = owner.call{value: address(this).balance}(""); require(sent, "Failed to send Ether");

Here is the improved withdraw function using .call() to send Ether, which is recommended since Solidity 0.6.x:

function withdraw() public {
    require(block.timestamp >= unlockTime, "You can't withdraw yet");
    require(msg.sender == owner, "You aren't the owner");

    emit Withdrawal(address(this).balance, block.timestamp);

    (bool sent, ) = owner.call{value: address(this).balance}("");
    require(sent, "Failed to send Ether");
}


This change will save gas and is the current recommended method to transfer Ether. However, you should be aware that using .call() with no gas stipend removes the gas limit of 2300, which is safe in this context because it's a simple transfer, but it should be used with caution when calling unknown contracts to prevent reentrancy attacks, so i  followed the Checks-Effects-Interactions pattern and used reentrancy guards to make your contract more secure.